### PR TITLE
webview: Update selector for all message.

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,6 +1,6 @@
 module.exports = (Franz) => {
     const getMessages = function getMessages() {
-        const allMessages = Math.round(document.querySelectorAll("#global_filters .home-link .count .value")[0].innerText);
+        const allMessages = Math.round(document.querySelectorAll("#global_filters .top_left_all_messages .count .value")[0].innerText);
         Franz.setBadge(allMessages);
     };
     Franz.loop(getMessages);


### PR DESCRIPTION
The `home-link` class is removed in the web app's left sidebar so this needs to be changed.